### PR TITLE
Move BSSN Initial Data Functionality to Own Function

### DIFF
--- a/BSSN_GR/cuda/src/bssnCtxGPU.cu
+++ b/BSSN_GR/cuda/src/bssnCtxGPU.cu
@@ -327,20 +327,10 @@ namespace bssn
                                 TwoPunctures((double)xx,(double)yy,(double)zz,var,
                                             &mp, &mm, &mp_adm, &mm_adm, &E, &J1, &J2, &J3);
                             }
-                            else if (bssn::BSSN_ID_TYPE == 1) {
-                                bssn::punctureData((double)x,(double)y,(double)z,var);
-                            }
-                            else if (bssn::BSSN_ID_TYPE == 2) {
-                                bssn::KerrSchildData((double)x,(double)y,(double)z,var);
-                            }
-                            else if (bssn::BSSN_ID_TYPE == 3) {
-                                bssn::noiseData((double)x,(double)y,(double)z,var);
-                            }
-                            else if (bssn::BSSN_ID_TYPE == 4) {
-                                bssn::fake_initial_data((double)x,(double)y,(double)z,var);
-                            }
                             else {
-                                std::cout<<"Unknown ID type"<<std::endl;
+                                // all other values are handled in the initial data wrapper including
+                                // an error message
+                                initialDataFunctionWrapper((double)x, (double)y, (double)z, var);
                             }
                             for(unsigned int v=0; v<bssn::BSSN_NUM_VARS; v++)
                                 zipIn[v][nodeLookUp_CG]=var[v];

--- a/BSSN_GR/cuda/src/gr_cuda.cu
+++ b/BSSN_GR/cuda/src/gr_cuda.cu
@@ -132,7 +132,7 @@ int main (int argc, char** argv)
 
     //2. generate the initial grid.
     std::vector<ot::TreeNode> tmpNodes;
-    std::function<void(double,double,double,double*)> f_init=[](double x,double y,double z,double*var){bssn::punctureData(x,y,z,var);};
+    std::function<void(double,double,double,double*)> f_init=[](double x,double y,double z,double*var){bssn::initialDataFunctionWrapper(x,y,z,var);};
     std::function<double(double,double,double)> f_init_alpha=[](double x,double y,double z){ double var[24]; bssn::punctureData(x,y,z,var); return var[0];};
     //std::function<void(double,double,double,double*)> f_init=[](double x,double y,double z,double*var){bssn::KerrSchildData(x,y,z,var);};
 

--- a/BSSN_GR/cuda_gr/include/gpuBSSNExample.h
+++ b/BSSN_GR/cuda_gr/include/gpuBSSNExample.h
@@ -80,17 +80,10 @@ namespace cuda
                                 TwoPunctures((double)x,(double)y,(double)z,var,
                                              &mp, &mm, &mp_adm, &mm_adm, &E, &J1, &J2, &J3);
                             }
-                            else if (bssn::BSSN_ID_TYPE == 1) {
-                                bssn::punctureData((double)x,(double)y,(double)z,var);
-                            }
-                            else if (bssn::BSSN_ID_TYPE == 2) {
-                                bssn::KerrSchildData((double)x,(double)y,(double)z,var);
-                            }
-                            else if (bssn::BSSN_ID_TYPE == 3) {
-                                bssn::fake_initial_data(x,y,z,var);//bssn::noiseData((double)x,(double)y,(double)z,var);
-                            }
                             else {
-                                std::cout<<"Unknwon ID type"<<std::endl;
+                                // all other values are handled in the initial data wrapper including
+                                // an error message
+                                initialDataFunctionWrapper((double)x, (double)y, (double)z, var);
                             }
                             for(unsigned int v=0;v<bssn::BSSN_NUM_VARS;v++)
                                 varIn[v][nodeLookUp_CG]=var[v];

--- a/BSSN_GR/include/grUtils.h
+++ b/BSSN_GR/include/grUtils.h
@@ -44,6 +44,30 @@ namespace bssn
      */
     void dumpParamFile(std::ostream& sout, int root, MPI_Comm comm);
 
+    /**
+     * @brief A general initial data function wrapper
+     *
+     * This function is designed to be called by the grid initialization. It can
+     * only take an x, y, and z position on the grid and fill out the proper
+     * variables array. If more variables are needed, special logic is required.
+     * As a reminder, the grid initialization done by Dendro's function2Octree
+     * routine cannot accept additional variables, so approximations are
+     * required for initial grid construction and refinement.
+     *
+     * However, in the bssnCtx object
+     * you can add additional logic in init_grid() to more accurately fill the
+     * grid with precise values (see BSSN_ID_TYPE 0 and how it calls
+     * punctureData() in this function and then calls TwoPunctures() in
+     * init_grid())
+     *
+     * @param xx_grid : the x coord (in octree/grid coords)
+     * @param yy_grid : the y coord (in octree/grid coords)
+     * @param zz_grid : the z coord (in octree/grid coords)
+     * @param var : initialized BSSN variables for the grid at the specified
+     * points
+     */
+    void initialDataFunctionWrapper(const double xx_grid, const double yy_grid,
+                                    const double zz_grid, double* var);
 
     /**
      * @brief Two puncture intiial data from HAD code/ 

--- a/BSSN_GR/include/zipUnzipTest.h
+++ b/BSSN_GR/include/zipUnzipTest.h
@@ -58,17 +58,10 @@ void applyInitialConditions(const ot::Mesh* mesh, T** zipIn)
                             TwoPunctures((double)x,(double)y,(double)z,var,
                                          &mp, &mm, &mp_adm, &mm_adm, &E, &J1, &J2, &J3);
                         }
-                        else if (bssn::BSSN_ID_TYPE == 1) {
-                            bssn::punctureData((double)x,(double)y,(double)z,var);
-                        }
-                        else if (bssn::BSSN_ID_TYPE == 2) {
-                            bssn::KerrSchildData((double)x,(double)y,(double)z,var);
-                        }
-                        else if (bssn::BSSN_ID_TYPE == 3) {
-                            bssn::noiseData((double)x,(double)y,(double)z,var);
-                        }
                         else {
-                            std::cout<<"Unknown ID type"<<std::endl;
+                            // all other values are handled in the initial data wrapper including
+                            // an error message
+                            initialDataFunctionWrapper((double)x, (double)y, (double)z, var);
                         }
                         for(unsigned int v=0;v<bssn::BSSN_NUM_VARS;v++)
                             zipIn[v][nodeLookUp_CG]=var[v];

--- a/BSSN_GR/src/bssnCtx.cpp
+++ b/BSSN_GR/src/bssnCtx.cpp
@@ -533,20 +533,10 @@ int BSSNCtx::init_grid() {
                             TwoPunctures((double)xx, (double)yy, (double)zz,
                                          var, &mp, &mm, &mp_adm, &mm_adm, &E,
                                          &J1, &J2, &J3);
-                        } else if (bssn::BSSN_ID_TYPE == 1) {
-                            bssn::punctureData((double)x, (double)y, (double)z,
-                                               var);
-                        } else if (bssn::BSSN_ID_TYPE == 2) {
-                            bssn::KerrSchildData((double)x, (double)y,
-                                                 (double)z, var);
-                        } else if (bssn::BSSN_ID_TYPE == 3) {
-                            bssn::noiseData((double)x, (double)y, (double)z,
-                                            var);
-                        } else if (bssn::BSSN_ID_TYPE == 4) {
-                            bssn::fake_initial_data((double)x, (double)y,
-                                                    (double)z, var);
                         } else {
-                            std::cout << "Unknown ID type" << std::endl;
+                            // all other values are handled in the initial data wrapper including
+                            // an error message
+                            initialDataFunctionWrapper((double)x, (double)y, (double)z, var);
                         }
                         for (unsigned int v = 0; v < bssn::BSSN_NUM_VARS; v++)
                             zipIn[v][nodeLookUp_CG] = var[v];

--- a/BSSN_GR/src/bssngr_main.cpp
+++ b/BSSN_GR/src/bssngr_main.cpp
@@ -129,8 +129,8 @@ int main (int argc, char** argv)
 
     //2. generate the initial grid.
     std::vector<ot::TreeNode> tmpNodes;
-    std::function<void(double,double,double,double*)> f_init=[](double x,double y,double z,double*var){bssn::punctureData(x,y,z,var);};
-    std::function<double(double,double,double)> f_init_alpha=[](double x,double y,double z){ double var[24]; bssn::punctureData(x,y,z,var); return var[0];};
+    std::function<void(double,double,double,double*)> f_init=[](double x,double y,double z,double*var){bssn::initialDataFunctionWrapper(x,y,z,var);};
+    std::function<double(double,double,double)> f_init_alpha=[](double x,double y,double z){ double var[24]; bssn::initialDataFunctionWrapper(x,y,z,var); return var[0];};
     //std::function<void(double,double,double,double*)> f_init=[](double x,double y,double z,double*var){bssn::KerrSchildData(x,y,z,var);};
 
     const unsigned int interpVars=bssn::BSSN_NUM_VARS;

--- a/BSSN_GR/src/grUtils.cpp
+++ b/BSSN_GR/src/grUtils.cpp
@@ -650,6 +650,68 @@ namespace bssn
         }
     }
 
+    void initialDataFunctionWrapper(const double xx_grid, const double yy_grid,
+                                    const double zz_grid, double* var) {
+        // code to convert grid functions to non-grid, if the function doesn't already support it
+        // const double xx = GRIDX_TO_X(xx_grid);
+        // const double yy = GRIDY_TO_Y(yy_grid);
+        // const double zz = GRIDZ_TO_Z(zz_grid);
+
+        switch (bssn::BSSN_ID_TYPE) {
+            case 0:
+                // NOTE: this is the TwoPunctures code! For **pure**
+                // initialization done when building up the grid before pure
+                // population, this calls bssn::punctureData which is simply the
+                // two puncture intiial data from HAD code. In bssnCtx.cpp's
+                // init_grid the bssn::BSSN_ID_TYPE switch will call the true
+                // TwoPunctures code which is the proper TPID initial data
+                bssn::punctureData(xx_grid, yy_grid, zz_grid, var);
+
+                break;
+
+            case 1:
+                // ID 1 is the puncture data function on its own
+                bssn::punctureData(xx_grid, yy_grid, zz_grid, var);
+
+                break;
+            
+            case 2:
+                // ID 2 is the KerrSchild Data
+                bssn::KerrSchildData(xx_grid, yy_grid, zz_grid, var);
+
+                break;
+            
+            case 3:
+                // ID 3 is a noise data
+                bssn::noiseData(xx_grid, yy_grid, zz_grid, var);
+
+                break;
+            
+            case 4:
+                // ID 4 is a fake initial data
+                bssn::fake_initial_data(xx_grid, yy_grid, zz_grid, var);
+
+                break;
+
+            // MORE CAN BE ADDED HERE
+
+            default:
+                int rank;
+                int npes;
+                MPI_Comm comm = MPI_COMM_WORLD;
+                MPI_Comm_rank(comm, &rank);
+                MPI_Comm_size(comm, &npes);
+                if (!rank) {
+                    std::cerr << RED << "ERROR::: Invalid initial data ID: " << bssn::BSSN_ID_TYPE << NRM
+                              << std::endl;
+                }
+
+                MPI_Abort(comm, 0);
+
+                break;
+        }
+    }
+
     void punctureDataPhysicalCoord(const double xx,const double yy,const double zz, double *var)
     {
         


### PR DESCRIPTION
This change "merges" the initial data functionality all into a single function. This helps with the population of the initial grid (so that it isn't just using the simplified Two Punctures code initially) and makes it simpler to add new Initial Data types for testing.

There are still a few caveats, if additional variables are needed during "true initialization" and not during the initial refinement stages, they need to be handled in the initialization function of the BSSNCtx object.

Either way, this makes it clearer where the pieces should go.