### PR TITLE
Fixing the AEH Solver from Crashing

### DIFF
--- a/BSSN_GR/include/aeh.h
+++ b/BSSN_GR/include/aeh.h
@@ -1413,7 +1413,7 @@ namespace aeh
 
         qoi.expansion_L2 = this->eval_expansion_norm(ctx, h_qs, aeh_f, aeh_h, interp_coords, 2);
 
-        T * aeh_qi_ptr              = aeh_f.get_vec_ptr();
+        T * aeh_qi_ptr              = aeh_qi.get_vec_ptr();
         this->eval_quasi_measurements_integrands(ctx, m_uiMesh, aeh_qi_ptr, h_qs);
         m_uiMesh->readFromGhostBegin(aeh_qi_ptr, NUM_QUASI_MEASURE_VARS);
 
@@ -1534,6 +1534,9 @@ namespace aeh
 
                 file_aeh<<"\"expansion_L2\":"<<ah_qoi.expansion_L2<<", ";
                 file_aeh<<"\"area\":"<<ah_qoi.area<<", ";
+                file_aeh<<"\"Jx\":"<<ah_qoi.Jx<<", ";
+                file_aeh<<"\"Jy\":"<<ah_qoi.Jy<<", ";
+                file_aeh<<"\"Jz\":"<<ah_qoi.Jz<<", ";
                 file_aeh<<"\"rmin\":"<<ah_qoi.rmin<<", ";
                 file_aeh<<"\"rmean\":"<<ah_qoi.rmean<<", ";
                 file_aeh<<"\"rmax\":"<<ah_qoi.rmax<<"";


### PR DESCRIPTION
This should fix the AEH solver. It had been crashing because of an out-of-bounds issue.